### PR TITLE
CMake improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ config.guess
 config.sub
 install-sh
 missing
+/build

--- a/cmake/Modules/ClhepOutOfSourceBuild.cmake
+++ b/cmake/Modules/ClhepOutOfSourceBuild.cmake
@@ -1,12 +1,10 @@
-# Throw a fatal error if cmake is invoked from within the source code directory tree
+# Throw a fatal error if cmake is invoked from the source code directory tree
 # clhep_ensure_out_of_source_build()
 #
 
 macro (clhep_ensure_out_of_source_build)
 
-  string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}" in_source)
-  string( REGEX MATCH "${CMAKE_SOURCE_DIR}/" in_source_subdir "${CMAKE_BINARY_DIR}")
-  if (in_source OR in_source_subdir)
+  if (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message(FATAL_ERROR "
 ERROR: In source builds of this project are not allowed.
 A separate build directory is required.

--- a/cmake/Modules/ClhepToolchain.cmake
+++ b/cmake/Modules/ClhepToolchain.cmake
@@ -26,7 +26,11 @@ macro(clhep_toolchain)
 # First we set the needed variables
 set(CLHEP_VERSION ${VERSION})
 set(CLHEP_DEFINITIONS )
-set(CLHEP_INCLUDE_DIR ${PROJECT_BINARY_DIR})
+set(CLHEP_INCLUDE_DIR "${PROJECT_BINARY_DIR}")
+set(CLHEP_INCLUDE_DIR_SETUP "
+# CLHEP configured for use from the build tree - absolute paths are used.
+set(CLHEP_INCLUDE_DIR \"${CLHEP_INCLUDE_DIR}\")
+")
 
 # Now we configure the CLHEPConfig and CLHEPConfigVersion file templates,
 # outputting to the top level of the build tree.
@@ -114,7 +118,10 @@ file(RELATIVE_PATH _relincpath
   ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/CLHEP-${VERSION}
   ${CMAKE_INSTALL_PREFIX}/include
   )
-set(CLHEP_INCLUDE_DIR "\${_thisdir}/${_relincpath}")
+set(CLHEP_INCLUDE_DIR_SETUP "
+# CLHEP configured for the install with relative paths, so use these
+get_filename_component(CLHEP_INCLUDE_DIR \"\${_thisdir}/${_relincpath}\" ABSOLUTE)
+  ")
 
 # Now we configure the CLHEPConfig and CLHEPConfigVersion file templates,
 # outputting to a directory in the build directory. This is simply a

--- a/cmake/Templates/CLHEPConfig.cmake.in
+++ b/cmake/Templates/CLHEPConfig.cmake.in
@@ -103,7 +103,7 @@ get_filename_component(_thisdir "${CMAKE_CURRENT_LIST_FILE}" PATH)
 # Configure the path to the CLHEP headers, using a relative path if possible.
 # This is only known at CMake time, so expand a CMake supplied variable
 # CLHEP has a nice simple header structure.
-set(CLHEP_INCLUDE_DIR @CLHEP_INCLUDE_DIR@)
+@CLHEP_INCLUDE_DIR_SETUP@
 
 #----------------------------------------------------------------------------
 # Construct the overall include path for using CLHEP


### PR DESCRIPTION
Hi @drbenmorgan , there doesn't seem to be an official mirror of CLHEP, but I'm not an official Geant4 collaborator and so can't submit pull requests to the main repo. The main change here, cribbed from Geant4, is to fix `-I${clhep_prefix}/../../include` from showing up in downstream projects. If you can pull this into the main CLHEP repo I would appreciate it!