### PR TITLE
Refinement of #1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,11 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/ClhepOutOfSourceBuild.cmake)
 clhep_ensure_out_of_source_build()
 
 # use cmake 3.2 or later
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.2...3.22)
+if(${CMAKE_VERSION} VERSION_LESS 3.12)
+  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+endif()
+
 # Project setup
 project(CLHEP VERSION 2.4.5.1)
 # - needed for (temporary) back compatibility

--- a/cmake/Modules/ClhepOutOfSourceBuild.cmake
+++ b/cmake/Modules/ClhepOutOfSourceBuild.cmake
@@ -1,22 +1,15 @@
-# Throw a fatal error if cmake is invoked from within the source code directory tree
+# Throw a fatal error if cmake is invoked from the source code directory tree
 # clhep_ensure_out_of_source_build()
 #
 
-# we need the full path here because we check for an out of source build before anything else
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/ClhepRegexEscape.cmake)
-
 macro (clhep_ensure_out_of_source_build)
+  string(FIND "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}" is_subdir_pos)
 
-  string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}" in_source)
-  clhep_regex_escape( "${CMAKE_SOURCE_DIR}" escaped_path)
-  set(my_source_dir "^${escaped_path}$")
-  clhep_regex_escape( "${CMAKE_BINARY_DIR}" escaped_path)
-  set(my_binary_dir "^${escaped_path}$")
-  string( REGEX MATCH "${my_source_dir}/" in_source_subdir "${my_binary_dir}")
-  if (in_source OR in_source_subdir)
+  if ((CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
+      OR (is_subdir_pos EQUAL 0))
   message(FATAL_ERROR "
 ERROR: In source builds of this project are not allowed.
-A separate build directory is required.
+A separate build directory outside of `${CMAKE_SOURCE_DIR}' is required.
 Please create one and run cmake from the build directory.
 Also note that cmake has just added files to your source code directory.
 We suggest getting a new copy of the source code.
@@ -24,4 +17,4 @@ Otherwise, delete `CMakeCache.txt' and the directory `CMakeFiles'.
   ")
   endif ()
 
-endmacro (clhep_ensure_out_of_source_build)
+endmacro ()

--- a/cmake/Modules/ClhepToolchain.cmake
+++ b/cmake/Modules/ClhepToolchain.cmake
@@ -15,6 +15,8 @@
 
 # code supplied by Ben Morgan Ben.Morgan@warwick.ac.uk
 
+include(CMakePackageConfigHelpers)
+
 macro(clhep_toolchain)
 
 #----------------------------------------------------------------------------
@@ -44,9 +46,10 @@ configure_file(${PROJECT_SOURCE_DIR}/cmake/Templates/CLHEPConfigVersion.cmake.in
   @ONLY
   )
 
-configure_file(${PROJECT_SOURCE_DIR}/cmake/Templates/CLHEPConfig.cmake.in
-  ${PROJECT_BINARY_DIR}/CLHEPConfig.cmake 
-  @ONLY
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/Templates/CLHEPConfig.cmake.in
+  ${PROJECT_BINARY_DIR}/CLHEPConfig.cmake
+  INSTALL_DESTINATION ${PROJECT_BINARY_DIR}
+  PATH_VARS CLHEP_INCLUDE_DIR
   )
 
 # We 'export' the main CLHEP library targets from the build tree.
@@ -100,19 +103,10 @@ endforeach()
 #----------------------------------------------------------------------------
 # - Now we handle the installation tree
 #
-# Again we set the needed variable first. Not all have actually changed,
+# Again we set the needed variables first. Not all have actually changed,
 # but we set again for clarity and just to be sure.
 set(CLHEP_VERSION ${VERSION})
-
-# The setup of the include dir is slightly different because we want
-# to make the install relocatable (Current CLHEP setup *is* relocatable).
-# We use a relative path from the directory where the CLHEPConfig.cmake
-# file is installed to the actual include dir. 
-file(RELATIVE_PATH _relincpath 
-  ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/CLHEP-${VERSION}
-  ${CMAKE_INSTALL_PREFIX}/include
-  )
-set(CLHEP_INCLUDE_DIR "\${_thisdir}/${_relincpath}")
+set(CLHEP_INCLUDE_DIR include)
 
 # Now we configure the CLHEPConfig and CLHEPConfigVersion file templates,
 # outputting to a directory in the build directory. This is simply a
@@ -122,9 +116,10 @@ configure_file(${PROJECT_SOURCE_DIR}/cmake/Templates/CLHEPConfigVersion.cmake.in
   @ONLY
   )
 
-configure_file(${PROJECT_SOURCE_DIR}/cmake/Templates/CLHEPConfig.cmake.in
-  ${PROJECT_BINARY_DIR}/InstallTreeFiles/CLHEPConfig.cmake 
-  @ONLY
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/Templates/CLHEPConfig.cmake.in
+  ${PROJECT_BINARY_DIR}/InstallTreeFiles/CLHEPConfig.cmake
+  INSTALL_DESTINATION lib${LIB_SUFFIX}/CLHEP-${VERSION} 
+  PATH_VARS CLHEP_INCLUDE_DIR
   )
 
 # Also configure the pkgconfig files, again outputting to a directory under

--- a/cmake/Templates/CLHEPConfig.cmake.in
+++ b/cmake/Templates/CLHEPConfig.cmake.in
@@ -73,33 +73,23 @@
 # not allowed.
 #
 
+@PACKAGE_INIT@
+
 #----------------------------------------------------------------------------
-# Locate ourselves, since all our config files should have been installed
-# alongside us...
+# Configure the non-target paths to the CLHEP headers
 #
-get_filename_component(_thisdir "${CMAKE_CURRENT_LIST_FILE}" PATH)
-
-
-#----------------------------------------------------------------------------
-# Configure the path to the CLHEP headers, using a relative path if possible.
-# This is only known at CMake time, so expand a CMake supplied variable
-# CLHEP has a nice simple header structure.
-set(CLHEP_INCLUDE_DIR @CLHEP_INCLUDE_DIR@)
-
-#----------------------------------------------------------------------------
-# Construct the overall include path for using CLHEP
-#
+set_and_check(CLHEP_INCLUDE_DIR "@PACKAGE_CLHEP_INCLUDE_DIR@")
 set(CLHEP_INCLUDE_DIRS ${CLHEP_INCLUDE_DIR})
 
 #----------------------------------------------------------------------------
 # Include the file listing all the imported targets.
-# This is installed in the same location as us...
 #
-include("${_thisdir}/CLHEPLibraryDepends.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/CLHEPLibraryDepends.cmake")
 
 #----------------------------------------------------------------------
-# - Handle shared vs static - default to shared if user didn't specify
-#   This is actually very simple because we always build both!
+# Handle shared vs static to fill the CLHEP_LIBRARIES variable
+# Default to shared if user didn't specify which. We always build
+# both types, so don't need to specify _FOUND vars. 
 set(CLHEP_KNOWN_COMPONENTS "@CLHEP_libraries@")
 
 # Only allow single library variant to be used to populate CLHEP_LIBRARIES
@@ -115,18 +105,16 @@ foreach(__clhep_component_lib ${CLHEP_KNOWN_COMPONENTS})
   endif()
 endforeach()
 
-# If CLHEP_LIBRARIES is empty at this point, then the complete lib is
-# needed
+# If CLHEP_LIBRARIES is empty here, then the complete lib is wanted
 if(NOT CLHEP_LIBRARIES)
   set(CLHEP_LIBRARIES CLHEP::CLHEP${__clhep_lib_suffix})
 endif()
 
 #-----------------------------------------------------------------------
-# Finally, handle any remaining components.
-# We should have dealt with all available components above, except for
-# ui_all and vis_all, and removed them from the list of FIND_COMPONENTS
-# so any left  we either didn't find or don't know about. Emit a warning
-# if REQUIRED isn't set, or FATAL_ERROR otherwise
+# Finally, handle any remaining components. As we've handled all known
+# ones above, any left we don't know about. Emit a warning
+# if REQUIRED isn't set, or FATAL_ERROR otherwise. We don't use the
+# CMake check_required_components macro to provide more info.
 #
 list(REMOVE_DUPLICATES CLHEP_FIND_COMPONENTS)
 
@@ -138,5 +126,3 @@ foreach(_remaining ${CLHEP_FIND_COMPONENTS})
   endif()
   unset(CLHEP_FIND_REQUIRED_${_remaining})
 endforeach()
-
-# And we should be good to go...


### PR DESCRIPTION
Hi @sethrj, following up from #1, I made a couple of updates using your changes as a basis:

1. I've retained, for now, the requirement for the build directory to be fully outside the source dir (CLHEP developers were pretty strict on this in the past, but we can discuss on upstream submit), but have simplified it in line with your change.
2. I've got rid of the relative (`..`) path in `CLHEP_INCLUDE_DIR` by migrating generation of `CLHEPConfig.cmake` to use CMake's [`CMakePackageConfigHelpers`](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html) module. It should still result in the same behaviour as your change but with the standard CMake functionality (and I need to do the same in Geant4!)

Let me know if these are reasonable for you and I'll submit to the CERN main repo (https://gitlab.cern.ch/CLHEP/CLHEP).